### PR TITLE
First argument to Popen expects a list, not a string

### DIFF
--- a/pipeffmpeg.py
+++ b/pipeffmpeg.py
@@ -108,7 +108,7 @@ def get_pipe3(option=None):
         if type(option) == list:
             cmd += option
     return sp.Popen(
-        " ".join(cmd),
+        cmd,
         stdin=sp.PIPE,
         stdout=sp.PIPE,
         stderr=sp.PIPE,
@@ -317,7 +317,7 @@ def get_info(path_of_video):
     _attempt_ffprobe()
     if FFPROBE_EXISTS:
         p = sp.Popen(
-            " ".join([FFPROBE_BIN, '-show_format', '-show_streams', path_of_video]),
+            [FFPROBE_BIN, '-show_format', '-show_streams', path_of_video],
             stdin=sp.PIPE,
             stdout=sp.PIPE,
             stderr=sp.PIPE,
@@ -423,7 +423,7 @@ class InputVideoStream:
             '-' # it means output to pipe
         ]
         self.p = sp.Popen(
-            " ".join(cmd),
+            cmd,
             stdin=sp.PIPE,
             stdout=sp.PIPE,
             stderr=sp.PIPE,
@@ -475,7 +475,7 @@ class OutVideoStream:
             self.filepath,
         ]
         self.p = sp.Popen(
-            " ".join(cmd),
+            cmd,
             stdin=sp.PIPE,
             stdout=sp.PIPE,
             stderr=sp.PIPE,

--- a/pipeffmpeg.py
+++ b/pipeffmpeg.py
@@ -407,14 +407,15 @@ def sread(fd,cobj):
 
 class InputVideoStream:
     """to read a video to writeout by frames and audio stream"""
-    def __init__(self, path=None):
+    def __init__(self, path='test.mp4'):
         self.rate = 15
         self.ivcodec = 'bmp'
-        self.filepath = 'test.mp4'
+        self.filepath = path
         self.frames = 10
         self.iformat = 'image2pipe'
 
     def open(self, path):
+        self.filepath = path
         cmd = [
             FFMPEG_BIN,
             '-i', self.filepath,


### PR DESCRIPTION
I found that this package raised exceptions for all of the Popen calls (under 2.7.2, at least), since Popen expects a list of strings for the command, while the lists were being joined together into strings.  Everything appears to work nicely once the lists are "unjoined".